### PR TITLE
ICU message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the DatoCMS AI Translations Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **ICU Message Format Support**: Full support for ICU message format strings
+  - Automatic detection and preservation of ICU message structure
+  - Support for plural, select, selectordinal, number, date, and time formats
+  - Proper handling of nested ICU messages and placeholders
+  - Compatible with next-intl, react-intl, FormatJS, and other i18n libraries
+  - Enhanced tokenization logic to differentiate ICU messages from simple placeholders
+  - Comprehensive test coverage for various ICU message patterns
+
+### Changed
+
+- **Improved Placeholder Handling**: Enhanced tokenization system to better distinguish between:
+  - ICU message format (e.g., `{count, plural, =0 {text} other {text}}`)
+  - Simple placeholders (e.g., `{name}`, `{{variable}}`)
+  - Printf-style tokens (e.g., `%s`, `%1$s`)
+  - Slug-style placeholders (e.g., `:slug`)
+
 ## [1.9.0] - 2025-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ The plugin includes a dedicated page for translating multiple models at once:
 
 ![AI Bulk Translations Page](https://github.com/user-attachments/assets/eefd5f25-efc7-4f3b-bf49-ff05d623b35c)
 
+## ICU Message Format Support
+
+The plugin fully supports [ICU message format](https://unicode-org.github.io/icu/userguide/format_parse/messages/) strings, commonly used in internationalization libraries like [next-intl](https://next-intl.dev/docs/usage/translations#icu-messages).
+
+ICU messages are automatically detected and handled correctly:
+
+```
+{count, plural, =0 {no items} =1 {one item} other {# items}}
+{gender, select, male {He} female {She} other {They}}
+{price, number, currency}
+{eventDate, date, long}
+```
+
+The plugin preserves the ICU structure while translating the text content within the message cases. This includes support for:
+
+- **Plural rules**: `{count, plural, ...}`
+- **Select statements**: `{gender, select, ...}`
+- **Number formatting**: `{price, number, ...}`
+- **Date/time formatting**: `{date, date, ...}` and `{time, time, ...}`
+- **Ordinal selection**: `{place, selectordinal, ...}`
+- **Nested ICU messages**: Complex messages with nested placeholders
+
+Simple placeholders like `{name}`, `{{variable}}`, `%s`, and `:slug` continue to work as expected and can be mixed with ICU messages in the same string.
+
 ## Contextual Translations
 
 The plugin now supports context-aware translations through the `{recordContext}` placeholder:

--- a/src/utils/translation/translateArray.ts
+++ b/src/utils/translation/translateArray.ts
@@ -17,16 +17,88 @@ type Options = {
 
 type TokenMap = { safe: string; orig: string }[];
 
+/**
+ * Checks if a curly brace section is an ICU message format.
+ * ICU messages have the pattern: \{variable, type, ...\}
+ * where type is one of: plural, select, selectordinal, number, date, time
+ * 
+ * @param text - The text to check for ICU message format
+ * @returns True if the text is an ICU message format
+ */
+function isICUMessage(text: string): boolean {
+  // Match ICU format: {variable, type, ...}
+  // The variable name followed by comma, then a known ICU type
+  const icuPattern = /^\{[^,}]+,\s*(plural|select|selectordinal|number|date|time)\s*,/;
+  return icuPattern.test(text);
+}
+
+/**
+ * Extracts the complete ICU message from text starting at a given position.
+ * Handles nested braces by counting depth.
+ * 
+ * @param text - The text to extract from
+ * @param startPos - The starting position in the text
+ * @returns An object with the extracted message and end position, or null if not an ICU message
+ */
+function extractICUMessage(text: string, startPos: number): { message: string; endPos: number } | null {
+  if (text[startPos] !== '{') return null;
+  
+  let depth = 0;
+  let i = startPos;
+  
+  while (i < text.length) {
+    if (text[i] === '{') {
+      depth++;
+    } else if (text[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        const message = text.substring(startPos, i + 1);
+        if (isICUMessage(message)) {
+          return { message, endPos: i + 1 };
+        }
+        return null;
+      }
+    }
+    i++;
+  }
+  
+  return null;
+}
+
 function tokenize(text: string): { safe: string; map: TokenMap } {
-  const patterns = [
-    /\{\{[^}]+\}\}/g, // {{var}}
-    /\{[^}]+\}/g,       // {var}
-    /%[0-9]*\$?[sd]/g,  // %s, %1$s
-    /:[a-zA-Z_][a-zA-Z0-9_-]*/g, // :slug
-  ];
   const map: TokenMap = [];
   let safe = text;
   let idx = 0;
+  
+  // First pass: temporarily protect ICU messages from being matched by placeholder patterns
+  // We'll use a special marker that won't match any of our patterns
+  const icuProtections: Array<{ marker: string; original: string }> = [];
+  let i = 0;
+  
+  while (i < safe.length) {
+    if (safe[i] === '{') {
+      const icuMatch = extractICUMessage(safe, i);
+      if (icuMatch) {
+        // Replace ICU message with a temporary marker
+        const marker = `⟪ICU_${icuProtections.length}⟫`;
+        icuProtections.push({ marker, original: icuMatch.message });
+        safe = safe.substring(0, i) + marker + safe.substring(icuMatch.endPos);
+        i += marker.length;
+        continue;
+      }
+    }
+    i++;
+  }
+  
+  // Second pass: apply standard placeholder patterns
+  // ICU messages are now protected and won't be matched
+  const patterns = [
+    /\{\{[^}]+\}\}/g, // {{var}}
+    /\{[^}]+\}/g,     // {var}
+    /%[0-9]*\$?[sd]/g,  // %s, %1$s
+    /:[a-zA-Z_][a-zA-Z0-9_-]*/g, // :slug
+  ];
+  
   for (const re of patterns) {
     safe = safe.replace(re, (m) => {
       const token = `⟦PH_${idx++}⟧`;
@@ -34,6 +106,12 @@ function tokenize(text: string): { safe: string; map: TokenMap } {
       return token;
     });
   }
+  
+  // Third pass: restore ICU messages
+  for (const { marker, original } of icuProtections) {
+    safe = safe.split(marker).join(original);
+  }
+  
   return { safe, map };
 }
 
@@ -47,8 +125,12 @@ function detokenize(text: string, map: TokenMap): string {
 
 /**
  * Translates an array of string segments from one locale to another.
- * Placeholders like `{{var}}`, `{slug}` and printf-style tokens are protected
+ * Placeholders like `\{\{var\}\}`, `\{slug\}` and printf-style tokens are protected
  * before sending to the provider and restored afterward.
+ * 
+ * ICU message format strings (e.g., `\{count, plural, =0 \{text\} other \{text\}\}`)
+ * are preserved and passed to the AI for translation, allowing the model to
+ * translate the content within while maintaining the ICU structure.
  *
  * @param provider - Active translation provider.
  * @param pluginParams - Plugin configuration and vendor-specific flags.
@@ -99,7 +181,7 @@ export async function translateArray(
       // Chat vendors: JSON-array prompt
       const from = fromLocale;
       const to = toLocale;
-      const instruction = `Translate the following array of strings from ${from} to ${to}. Return ONLY a valid JSON array of the exact same length, preserving placeholders like {foo}, {{bar}}, and tokens like ⟦PH_0⟧. Do not explain.`;
+      const instruction = `Translate the following array of strings from ${from} to ${to}. Return ONLY a valid JSON array of the exact same length, preserving placeholders like {foo}, {{bar}}, and tokens like ⟦PH_0⟧. For ICU message format (e.g., {count, plural, ...}), translate only the text content within the nested braces while preserving the ICU structure. Do not explain.`;
       const arrayLiteral = JSON.stringify(protectedSegments);
       const prompt = `${instruction}\n${arrayLiteral}`;
       const txt = await provider.completeText(prompt);

--- a/tests/unit/translateArray.test.ts
+++ b/tests/unit/translateArray.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi } from 'vitest';
+import { translateArray } from '../../src/utils/translation/translateArray';
+import type { TranslationProvider } from '../../src/utils/translation/types';
+
+// Mock plugin params
+const pluginParams = {
+  gptModel: 'gpt-4.1-mini',
+  apiKey: 'test-key',
+  translationFields: ['single_line'],
+  prompt: '{fieldValue}',
+} as any;
+
+// Helper to create mock provider
+function createMockProvider(completeTextFn: (prompt: string) => Promise<string>): TranslationProvider {
+  return {
+    vendor: 'openai',
+    capabilities: { streaming: false },
+    completeText: vi.fn(completeTextFn),
+    streamText: async function* () { yield ''; },
+  };
+}
+
+describe('translateArray - ICU Message Format Support', () => {
+  it('should handle ICU plural messages without tokenizing them', async () => {
+    const mockProvider = createMockProvider(async (prompt: string) => {
+      // Check that the ICU message structure is preserved in the prompt
+      expect(prompt).toContain('{count, plural,');
+      expect(prompt).toContain('=0 {');
+      expect(prompt).toContain('=1 {');
+      expect(prompt).toContain('other {');
+      
+      // Return a translated version
+      return JSON.stringify([
+        'Du har {count, plural, =0 {inga följare ännu} =1 {en följare} other {# följare}}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['You have {count, plural, =0 {no followers yet} =1 {one follower} other {# followers}}.'],
+      'en',
+      'sv'
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe('Du har {count, plural, =0 {inga följare ännu} =1 {en följare} other {# följare}}.');
+    expect(mockProvider.completeText).toHaveBeenCalledOnce();
+  });
+
+  it('should handle ICU select messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        '{gender, select, male {Il} female {Elle} other {Ils/Elles}} est en ligne.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['{gender, select, male {He} female {She} other {They}} is online.'],
+      'en',
+      'fr'
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('{gender, select,');
+    expect(mockProvider.completeText).toHaveBeenCalledOnce();
+  });
+
+  it('should handle deeply nested ICU messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        '{taxableArea, select, yes {An additional {taxRate, number, percent} tax will be collected.} other {No taxes apply.}}'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['{taxableArea, select, yes {An additional {taxRate, number, percent} tax will be collected.} other {No taxes apply.}}'],
+      'en',
+      'en'
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('{taxableArea, select,');
+    expect(result[0]).toContain('{taxRate, number, percent}');
+  });
+
+  it('should preserve simple placeholders while handling ICU messages', async () => {
+    const mockProvider = createMockProvider(async (prompt: string) => {
+      // Check that simple placeholders are tokenized
+      expect(prompt).toContain('⟦PH_0⟧');
+      // But ICU messages are not
+      expect(prompt).toContain('{count, plural,');
+      
+      return JSON.stringify([
+        'Bonjour ⟦PH_0⟧, vous avez {count, plural, =0 {aucun message} =1 {un message} other {# messages}}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Hello {name}, you have {count, plural, =0 {no messages} =1 {one message} other {# messages}}.'],
+      'en',
+      'fr'
+    );
+
+    expect(result).toHaveLength(1);
+    // Simple placeholder should be restored
+    expect(result[0]).toContain('{name}');
+    // ICU message should be preserved
+    expect(result[0]).toContain('{count, plural,');
+  });
+
+  it('should handle ICU number format messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        'Le prix est {price, number, currency}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['The price is {price, number, currency}.'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toContain('{price, number, currency}');
+  });
+
+  it('should handle ICU date format messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        'Die Veranstaltung findet am {eventDate, date, long} statt.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['The event is on {eventDate, date, long}.'],
+      'en',
+      'de'
+    );
+
+    expect(result[0]).toContain('{eventDate, date, long}');
+  });
+
+  it('should handle ICU time format messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        'La reunión es a las {meetingTime, time, short}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['The meeting is at {meetingTime, time, short}.'],
+      'en',
+      'es'
+    );
+
+    expect(result[0]).toContain('{meetingTime, time, short}');
+  });
+
+  it('should handle ICU selectordinal messages', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        'C\'est votre {place, selectordinal, one {#er} two {#ème} few {#ème} other {#ème}} essai.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['This is your {place, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} try.'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toContain('{place, selectordinal,');
+  });
+
+  it('should handle multiple ICU messages in one string', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        '{name} tiene {count, plural, =0 {sin artículos} =1 {un artículo} other {# artículos}} en {status, select, cart {carrito} wishlist {lista de deseos} other {otra ubicación}}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['{name} has {count, plural, =0 {no items} =1 {one item} other {# items}} in {status, select, cart {cart} wishlist {wishlist} other {other location}}.'],
+      'en',
+      'es'
+    );
+
+    expect(result[0]).toContain('{count, plural,');
+    expect(result[0]).toContain('{status, select,');
+    expect(result[0]).toContain('{name}');
+  });
+
+  it('should handle mixed placeholder types correctly', async () => {
+    const mockProvider = createMockProvider(async (prompt: string) => {
+      // Double brace placeholders should be tokenized
+      expect(prompt).toContain('⟦PH_0⟧');
+      // Printf-style should be tokenized
+      expect(prompt).toContain('⟦PH_1⟧');
+      // ICU messages should NOT be tokenized
+      expect(prompt).toContain('{count, plural,');
+      
+      return JSON.stringify([
+        'Bonjour ⟦PH_0⟧! Message ⟦PH_1⟧: Vous avez {count, plural, =0 {aucune notification} other {# notifications}}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Hello {{username}}! Message %s: You have {count, plural, =0 {no notifications} other {# notifications}}.'],
+      'en',
+      'fr'
+    );
+
+    // All placeholders should be restored
+    expect(result[0]).toContain('{{username}}');
+    expect(result[0]).toContain('%s');
+    expect(result[0]).toContain('{count, plural,');
+  });
+
+  it('should handle edge case with simple placeholder that looks like ICU start', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify([
+        'Utilisateur ⟦PH_0⟧ connecté'
+      ]);
+    });
+
+    // This is NOT an ICU message (no ICU type keyword)
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['User {id} logged in'],
+      'en',
+      'fr'
+    );
+
+    // Simple placeholder should be restored
+    expect(result[0]).toContain('{id}');
+  });
+
+  it('should not tokenize a placeholder with comma if it is an ICU message', async () => {
+    const mockProvider = createMockProvider(async (prompt: string) => {
+      console.log('Captured prompt:', prompt);
+      // ICU messages should NOT be tokenized - the entire ICU structure should be preserved
+      expect(prompt).toContain('{count, plural,');
+      expect(prompt).toContain('=0 {no items}');
+      expect(prompt).toContain('other {# items}');
+      
+      // Check if there are any PH tokens in the JSON array part (not the instruction)
+      const jsonArrayMatch = prompt.match(/\[(.*)\]/s);
+      if (jsonArrayMatch) {
+        const arrayPart = jsonArrayMatch[0];
+        console.log('Array part:', arrayPart);
+        // The array part should not have tokens since we only have an ICU message
+        expect(arrayPart).not.toContain('⟦PH_');
+      }
+      
+      return JSON.stringify([
+        'Sie haben {count, plural, =0 {keine Artikel} other {# Artikel}}.'
+      ]);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['You have {count, plural, =0 {no items} other {# items}}.'],
+      'en',
+      'de'
+    );
+
+    // Verify the result has the ICU message intact
+    expect(result[0]).toContain('{count, plural,');
+    expect(result[0]).toContain('keine Artikel');
+  });
+});
+
+describe('translateArray - Standard Placeholder Protection', () => {
+  it('should tokenize and restore simple placeholders', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify(['Bonjour ⟦PH_0⟧']);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Hello {name}'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toBe('Bonjour {name}');
+  });
+
+  it('should tokenize and restore double-brace placeholders', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify(['Bonjour ⟦PH_0⟧']);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Hello {{username}}'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toBe('Bonjour {{username}}');
+  });
+
+  it('should tokenize and restore printf-style placeholders', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify(['Message ⟦PH_0⟧: ⟦PH_1⟧']);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Message %s: %1$s'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toBe('Message %s: %1$s');
+  });
+
+  it('should tokenize and restore slug-style placeholders', async () => {
+    const mockProvider = createMockProvider(async () => {
+      return JSON.stringify(['Voir l\'article ⟦PH_0⟧']);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['See article :slug'],
+      'en',
+      'fr'
+    );
+
+    expect(result[0]).toBe('Voir l\'article :slug');
+  });
+
+  it('should NOT tokenize plugin template placeholders (they are replaced before translateArray)', async () => {
+    // These template placeholders like {recordContext}, {fromLocale}, {toLocale}, {fieldValue}
+    // are replaced by the prompt template system BEFORE content reaches translateArray.
+    // This test verifies that IF they somehow reached translateArray, they would be tokenized
+    // as simple placeholders (which is correct behavior, since they shouldn't be in user content).
+    
+    const mockProvider = createMockProvider(async () => {
+      // They should be tokenized like simple placeholders
+      return JSON.stringify(['Traduire ⟦PH_0⟧ de ⟦PH_1⟧ à ⟦PH_2⟧: ⟦PH_3⟧']);
+    });
+
+    const result = await translateArray(
+      mockProvider,
+      pluginParams,
+      ['Translate {recordContext} from {fromLocale} to {toLocale}: {fieldValue}'],
+      'en',
+      'fr'
+    );
+
+    // They should be restored as simple placeholders (but in reality, they're replaced before this)
+    expect(result[0]).toBe('Traduire {recordContext} de {fromLocale} à {toLocale}: {fieldValue}');
+  });
+});
+


### PR DESCRIPTION
A quick attempt at adding support for ICU messages, as proposed by myself in #9.

- Reworks tokenization to support [ICU messages](https://next-intl.dev/docs/usage/translations#icu-messages) in different shapes.
- Adds tests for `translateArray` utility
- Updates changelog and readme with details about changes

Closes #9 